### PR TITLE
fix(BREAKING): only pass the output result locally

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -40,13 +40,17 @@ else
 fi
 
 # look for the available terragrunt modules
-if buildkite-agent meta-data exists "terragrunt-workspace-module-groups" ; then 
-  module_groups="$(buildkite-agent meta-data get "terragrunt-workspace-module-groups")"
+MODULE_GROUP_OUTPUT_PATH="${BUILDKITE_PLUGIN_TERRAGRUNT_WORKSPACE_OUTPUT_MODULE_GROUPS_PATH-".terragrunt_module_groups_output.json"}"
+
+# check to see if the output path exists and has content
+if [[ -s "${MODULE_GROUP_OUTPUT_PATH}" ]] ; then
+  MODULE_GROUPS="$(cat "${MODULE_GROUP_OUTPUT_PATH}")"
 else
   # shellcheck disable=SC2068
-  module_groups="$(terragrunt output-module-groups --terragrunt-working-dir "${MODULE_DIR}" ${terragrunt_args[@]})"
+  MODULE_GROUPS="$(terragrunt output-module-groups --terragrunt-working-dir "${MODULE_DIR}" ${terragrunt_args[@]})"
 fi
-discovered_modules_list="$(echo "${module_groups}" | jq -r '[keys[] as $k | .[$k] ]| flatten | .[]')"
+
+discovered_modules_list="$(echo "${MODULE_GROUPS}" | jq -r '[keys[] as $k | .[$k] ]| flatten | .[]')"
 
 discovered_modules=()
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -12,6 +12,11 @@ configuration:
       description: The path to the modules that you want to apply
       type: string
 
+    output_module_groups_path:
+      description: The path to a file where the  output from `terragrunt output-module-groups` has been saved. Used in a command when your agent doesn't have access to terragrunt
+      type: string
+      default: ".terragrunt_module_groups_output.json"
+
     allowed_modules:
       description: A list of modules that can be used by this plugin
       type: array

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,1 +1,2 @@
 .outputs
+.data


### PR DESCRIPTION
- Moves locating the output command when run externally to a file output instead of a metadata output. The output is only required in the hook script and passing it in the metadata when there are mulitple pipelie invokes in a pipeline causes issues with which value is looked up.